### PR TITLE
[EEMW-11] | support icon and size in Select component

### DIFF
--- a/src/app/playground/page.tsx
+++ b/src/app/playground/page.tsx
@@ -5,7 +5,7 @@ import { TooltipWrap } from "@/components/ui/tooltip";
 import Select from "@/components/ui/select";
 import Accordion from "@/components/ui/accordion";
 
-import { PiIcon } from "lucide-react";
+import { PiIcon, MapIcon } from "lucide-react";
 
 const TooltipedButton = TooltipWrap(Button);
 
@@ -44,10 +44,11 @@ const Playground = () => {
         </Button>
       </div>
       ----------------------------------------------------------------------------------------------------------------------------------------------------------
-      <h1>Select with groups</h1>
-      <div className="bg-eros-bg p-6 flex gap-4 my-4">
+      <h1>Select with groups and icons</h1>
+      <div className="bg-eros-bg p-6 flex gap-12 my-4">
         <Select
           defaultValue="nl"
+          icon={<MapIcon height={15} width={15} />}
           options={[
             {
               label: "Primary Languages",
@@ -66,11 +67,58 @@ const Playground = () => {
               ],
             },
           ]}
+          size="sm"
+        />
+        <Select
+          defaultValue="nl"
+          icon={<MapIcon height={15} width={15} />}
+          options={[
+            {
+              label: "Primary Languages",
+              items: [
+                { value: "nl", label: "Dutch" },
+                { value: "en", label: "English" },
+                { value: "de", label: "Deutsch" },
+              ],
+            },
+            {
+              label: "Secondary Languages",
+              items: [
+                { value: "al", label: "Albanian" },
+                { value: "pl", label: "Polish" },
+                { value: "br", label: "Brasilian" },
+              ],
+            },
+          ]}
+          size="md"
+        />
+        <Select
+          defaultValue="nl"
+          icon={<MapIcon height={15} width={15} />}
+          options={[
+            {
+              label: "Primary Languages",
+              items: [
+                { value: "nl", label: "Dutch" },
+                { value: "en", label: "English" },
+                { value: "de", label: "Deutsch" },
+              ],
+            },
+            {
+              label: "Secondary Languages",
+              items: [
+                { value: "al", label: "Albanian" },
+                { value: "pl", label: "Polish" },
+                { value: "br", label: "Brasilian" },
+              ],
+            },
+          ]}
+          size="lg"
         />
       </div>
       ----------------------------------------------------------------------------------------------------------------------------------------------------------
       <h1>Select without groups</h1>
-      <div className="bg-eros-bg p-6 flex gap-4 my-4">
+      <div className="bg-eros-bg p-6 flex gap-12 my-4">
         <Select
           defaultValue="nl"
           options={[
@@ -78,6 +126,25 @@ const Playground = () => {
             { value: "en", label: "English" },
             { value: "de", label: "Deutsch" },
           ]}
+          size="sm"
+        />
+        <Select
+          defaultValue="nl"
+          options={[
+            { value: "nl", label: "Dutch" },
+            { value: "en", label: "English" },
+            { value: "de", label: "Deutsch" },
+          ]}
+          size="md"
+        />
+        <Select
+          defaultValue="nl"
+          options={[
+            { value: "nl", label: "Dutch" },
+            { value: "en", label: "English" },
+            { value: "de", label: "Deutsch" },
+          ]}
+          size="lg"
         />
       </div>
       ----------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/src/components/filters/GenderSelect/GenderSelect.tsx
+++ b/src/components/filters/GenderSelect/GenderSelect.tsx
@@ -1,0 +1,44 @@
+import { BookHeartIcon } from "lucide-react";
+import React from "react";
+
+import Select from "@/components/ui/select";
+import {
+  GroupedOption,
+  Option,
+  SelectComponentProps,
+} from "@/components/ui/select/Select";
+
+const defaultOptions = [
+  { label: "Male", value: "male" },
+  { label: "Female", value: "female" },
+  { label: "Transsexual", value: "trans" },
+];
+
+interface GenderSelectProps extends Omit<SelectComponentProps, "options"> {
+  options?: Option[] | GroupedOption[];
+}
+
+const GenderSelect = ({
+  defaultValue,
+  value,
+  options,
+  ...other
+}: GenderSelectProps) => {
+  const localOptions = options || defaultOptions;
+
+  return (
+    <div className="w-full">
+      <Select
+        {...other}
+        defaultValue={defaultValue}
+        hideChevronIcon
+        icon={<BookHeartIcon height={15} width={15} />}
+        options={localOptions}
+        placeholder="Gender"
+        value={value}
+      />
+    </div>
+  );
+};
+
+export default GenderSelect;

--- a/src/components/filters/GenderSelect/index.ts
+++ b/src/components/filters/GenderSelect/index.ts
@@ -1,0 +1,2 @@
+import GenderSelect from "./GenderSelect";
+export default GenderSelect;

--- a/src/components/filters/LocationSelect/LocationSelect.tsx
+++ b/src/components/filters/LocationSelect/LocationSelect.tsx
@@ -1,0 +1,56 @@
+import { LocateIcon } from "lucide-react";
+import React from "react";
+
+import Select from "@/components/ui/select";
+import {
+  GroupedOption,
+  Option,
+  SelectComponentProps,
+} from "@/components/ui/select/Select";
+
+const defaultOptions = [
+  {
+    label: "Belgium",
+    items: [
+      { label: "Antwerp", value: "antwerp" },
+      { label: "Brussels", value: "brussels" },
+      { label: "Ghent", value: "ghent" },
+    ],
+  },
+  {
+    label: "Netherlands",
+    items: [
+      { label: "Amsterdam", value: "amsterdam" },
+      { label: "Rotterdam", value: "rotterdam" },
+    ],
+  },
+];
+
+interface LocationSelectProps extends Omit<SelectComponentProps, "options"> {
+  options?: Option[] | GroupedOption[];
+}
+
+const LocationSelect = ({
+  defaultValue,
+  value,
+  options,
+  ...other
+}: LocationSelectProps) => {
+  const localOptions = options || defaultOptions;
+
+  return (
+    <div className="w-full">
+      <Select
+        {...other}
+        defaultValue={defaultValue}
+        hideChevronIcon
+        icon={<LocateIcon height={15} width={15} />}
+        options={localOptions}
+        placeholder="Place"
+        value={value}
+      />
+    </div>
+  );
+};
+
+export default LocationSelect;

--- a/src/components/filters/LocationSelect/LocationSelect.tsx
+++ b/src/components/filters/LocationSelect/LocationSelect.tsx
@@ -1,4 +1,4 @@
-import { LocateIcon } from "lucide-react";
+import { Map } from "lucide-react";
 import React from "react";
 
 import Select from "@/components/ui/select";
@@ -44,7 +44,7 @@ const LocationSelect = ({
         {...other}
         defaultValue={defaultValue}
         hideChevronIcon
-        icon={<LocateIcon height={15} width={15} />}
+        icon={<Map height={15} width={15} />}
         options={localOptions}
         placeholder="Place"
         value={value}

--- a/src/components/filters/LocationSelect/index.ts
+++ b/src/components/filters/LocationSelect/index.ts
@@ -1,0 +1,2 @@
+import LocationSelect from "./LocationSelect";
+export default LocationSelect;

--- a/src/components/ui/select/Select.tsx
+++ b/src/components/ui/select/Select.tsx
@@ -5,9 +5,11 @@ import {
   SelectContent,
   SelectItem,
   SelectLabel,
+  SelectGroup,
+  SelectValue,
 } from "./components";
-import { SelectGroup, SelectValue } from "./components";
 import { SelectProps } from "@radix-ui/react-select";
+import { cn } from "@/lib/utils";
 
 export interface Option {
   value: string;
@@ -24,10 +26,12 @@ export type SelectSize = "sm" | "md" | "lg";
 interface SelectComponentProps extends SelectProps {
   options: Option[] | GroupedOption[];
   placeholder?: string;
-  size?: Size;
+  icon?: React.ReactNode;
+  hideChevronIcon?: boolean;
+  size?: SelectSize;
 }
 
-const sizeClasses: Record<Size, string> = {
+const sizeClasses: Record<SelectSize, string> = {
   sm: "h-7 text-sm min-w-[100px]",
   md: "h-9 text-sm min-w-[150px]",
   lg: "h-11 text-sm min-w-[200px]",
@@ -36,6 +40,8 @@ const sizeClasses: Record<Size, string> = {
 const Select: React.FC<SelectComponentProps> = ({
   options,
   placeholder = "Select...",
+  icon,
+  hideChevronIcon = false,
   size = "md",
   ...other
 }) => {
@@ -46,10 +52,20 @@ const Select: React.FC<SelectComponentProps> = ({
       <SelectTrigger
         className={cn(
           "!w-full",
+          {
+            "[&>svg]:hidden": hideChevronIcon,
+          },
           sizeClasses[size]
         )}
       >
-        <SelectValue placeholder={placeholder} />
+        {icon ? (
+          <div className="flex items-center">
+            <span className="mr-2 max-h-fit">{icon}</span>
+            <SelectValue placeholder={placeholder} />
+          </div>
+        ) : (
+          <SelectValue placeholder={placeholder} />
+        )}
       </SelectTrigger>
       <SelectContent>
         {isGrouped

--- a/src/components/ui/select/Select.tsx
+++ b/src/components/ui/select/Select.tsx
@@ -9,31 +9,46 @@ import {
 import { SelectGroup, SelectValue } from "./components";
 import { SelectProps } from "@radix-ui/react-select";
 
-type Option = {
+export interface Option {
   value: string;
   label: string;
-};
+}
 
-type GroupedOption = {
+export interface GroupedOption {
   label: string;
   items: Option[];
-};
+}
+
+export type SelectSize = "sm" | "md" | "lg";
 
 interface SelectComponentProps extends SelectProps {
   options: Option[] | GroupedOption[];
   placeholder?: string;
+  size?: Size;
 }
+
+const sizeClasses: Record<Size, string> = {
+  sm: "h-7 text-sm min-w-[100px]",
+  md: "h-9 text-sm min-w-[150px]",
+  lg: "h-11 text-sm min-w-[200px]",
+};
 
 const Select: React.FC<SelectComponentProps> = ({
   options,
   placeholder = "Select...",
+  size = "md",
   ...other
 }) => {
   const isGrouped = "items" in options[0];
 
   return (
     <SelectComponent {...other}>
-      <SelectTrigger className="w-[280px]">
+      <SelectTrigger
+        className={cn(
+          "!w-full",
+          sizeClasses[size]
+        )}
+      >
         <SelectValue placeholder={placeholder} />
       </SelectTrigger>
       <SelectContent>

--- a/src/components/ui/select/Select.tsx
+++ b/src/components/ui/select/Select.tsx
@@ -23,7 +23,7 @@ export interface GroupedOption {
 
 export type SelectSize = "sm" | "md" | "lg";
 
-interface SelectComponentProps extends SelectProps {
+export interface SelectComponentProps extends SelectProps {
   options: Option[] | GroupedOption[];
   placeholder?: string;
   icon?: React.ReactNode;

--- a/src/components/ui/select/index.ts
+++ b/src/components/ui/select/index.ts
@@ -1,2 +1,4 @@
 import Select from "./Select";
+
+export type { GroupedOption, Option, SelectSize } from "./Select";
 export default Select;


### PR DESCRIPTION
### Link to issue

[EEMW-11]

### Description

Adds support for passing icons to the select component, and also size variants.

### To check locally

![Screenshot 2024-11-13 at 23 30 38](https://github.com/user-attachments/assets/6dd3b7d4-acff-403c-b694-9fcf75aed112)



