### PR TITLE
[EEMW-11] | Show Quick filters 

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -35,3 +35,12 @@ body {
   background: var(--background) !important;
   font-family: Arial, Helvetica, sans-serif;
 }
+
+.hide-scrollbar {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+.hide-scrollbar::-webkit-scrollbar {
+  display: none;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -29,12 +29,9 @@
 }
 
 html,
-main {
-  color: var(--foreground);
-  background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
-}
-
+main,
 body {
-  background: transparent;
+  color: var(--foreground) !important;
+  background: var(--background) !important;
+  font-family: Arial, Helvetica, sans-serif;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,11 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
 
-import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 
 import "./globals.css";
+import QuickFilters from "@/components/QuickFilters";
+import Navbar from "@/components/Navbar";
 
 const ceraPro = localFont({
   src: [
@@ -55,10 +56,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${ceraPro.variable} lg:container font-cerapro flex flex-col min-h-screen antialiased`}
+        className={`${ceraPro.variable} font-cerapro flex flex-col min-h-screen antialiased`}
       >
         <Navbar />
-        <main>{children}</main>
+        <QuickFilters />
+        <main className="lg:container">{children}</main>
         <Footer />
       </body>
     </html>

--- a/src/app/playground/page.tsx
+++ b/src/app/playground/page.tsx
@@ -48,7 +48,7 @@ const Playground = () => {
       <div className="bg-eros-bg p-6 flex gap-12 my-4">
         <Select
           defaultValue="nl"
-          icon={<MapIcon height={15} width={15} />}
+          icon={MapIcon}
           options={[
             {
               label: "Primary Languages",
@@ -71,7 +71,7 @@ const Playground = () => {
         />
         <Select
           defaultValue="nl"
-          icon={<MapIcon height={15} width={15} />}
+          icon={MapIcon}
           options={[
             {
               label: "Primary Languages",
@@ -94,7 +94,7 @@ const Playground = () => {
         />
         <Select
           defaultValue="nl"
-          icon={<MapIcon height={15} width={15} />}
+          icon={MapIcon}
           options={[
             {
               label: "Primary Languages",

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -4,83 +4,85 @@ import React from "react";
 
 const Footer = () => {
   return (
-    <footer className="flex flex-col gap-16 border-t border-white py-8 px-6">
-      <div className="flex flex-col lg:flex-row gap-8 lg:gap-16">
-        <div className="lg:w-1/4">
-          <Image
-            alt="Eros Elite logo"
-            height={54}
-            priority
-            sizes="(max-width: 1023px) 100px, (min-width: 1023px) 140px"
-            src="/EE_LOGO_SMALL.webp"
-            width={140}
-          />
-          <p className="mt-4 text-sm sm:pr-8">
-            Zoekt u een date met een escorte, gigolo of een privéhuis voor een
-            massage of meer? Redlights is dè website waar u een afspraakje kan
-            maken voor privé ontvangst, escort, massage of met swingers.
-          </p>
-        </div>
+    <footer className="border-t border-border-light">
+      <div className="lg:container flex flex-col gap-16 py-8 px-6">
+        <div className="flex flex-col lg:flex-row gap-8 lg:gap-16">
+          <div className="lg:w-1/4">
+            <Image
+              alt="Eros Elite logo"
+              height={54}
+              priority
+              sizes="(max-width: 1023px) 100px, (min-width: 1023px) 140px"
+              src="/EE_LOGO_SMALL.webp"
+              width={140}
+            />
+            <p className="mt-4 text-sm sm:pr-8">
+              Zoekt u een date met een escorte, gigolo of een privéhuis voor een
+              massage of meer? Redlights is dè website waar u een afspraakje kan
+              maken voor privé ontvangst, escort, massage of met swingers.
+            </p>
+          </div>
 
-        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-12 text-sm">
-          <div>
-            <h3 className="text-md font-semibold mb-2">Popular cities</h3>
-            <ul className="foreground-200">
-              <li className="foreground-200">Antwerp</li>
-              <li>Brussels</li>
-              <li>Ghent</li>
-              <li>Leuven</li>
-            </ul>
-          </div>
-          <div>
-            <h3 className="text-md font-semibold mb-2">Links</h3>
-            <ul className="foreground-200">
-              <li>Link 1</li>
-              <li>Link 2</li>
-              <li>Link 3</li>
-              <li>Link 4</li>
-            </ul>
-          </div>
-          <div>
-            <h3 className="text-md font-semibold mb-2">Categories</h3>
-            <ul className="foreground-200">
-              <li>Category 1</li>
-              <li>Category 2</li>
-              <li>Category 3</li>
-              <li>Category 4</li>
-            </ul>
-          </div>
-          <div>
-            <h3 className="text-md font-semibold mb-2">Popular cities</h3>
-            <ul className="foreground-200">
-              <li>Antwerp</li>
-              <li>Brussels</li>
-              <li>Ghent</li>
-              <li>Leuven</li>
-            </ul>
-          </div>
-          <div>
-            <h3 className="text-md font-semibold mb-2">Popular cities</h3>
-            <ul className="foreground-200">
-              <li>Antwerp</li>
-              <li>Brussels</li>
-              <li>Ghent</li>
-              <li>Leuven</li>
-            </ul>
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-12 text-sm">
+            <div>
+              <h3 className="text-md font-semibold mb-2">Popular cities</h3>
+              <ul className="foreground-200">
+                <li className="foreground-200">Antwerp</li>
+                <li>Brussels</li>
+                <li>Ghent</li>
+                <li>Leuven</li>
+              </ul>
+            </div>
+            <div>
+              <h3 className="text-md font-semibold mb-2">Links</h3>
+              <ul className="foreground-200">
+                <li>Link 1</li>
+                <li>Link 2</li>
+                <li>Link 3</li>
+                <li>Link 4</li>
+              </ul>
+            </div>
+            <div>
+              <h3 className="text-md font-semibold mb-2">Categories</h3>
+              <ul className="foreground-200">
+                <li>Category 1</li>
+                <li>Category 2</li>
+                <li>Category 3</li>
+                <li>Category 4</li>
+              </ul>
+            </div>
+            <div>
+              <h3 className="text-md font-semibold mb-2">Popular cities</h3>
+              <ul className="foreground-200">
+                <li>Antwerp</li>
+                <li>Brussels</li>
+                <li>Ghent</li>
+                <li>Leuven</li>
+              </ul>
+            </div>
+            <div>
+              <h3 className="text-md font-semibold mb-2">Popular cities</h3>
+              <ul className="foreground-200">
+                <li>Antwerp</li>
+                <li>Brussels</li>
+                <li>Ghent</li>
+                <li>Leuven</li>
+              </ul>
+            </div>
           </div>
         </div>
-      </div>
-      <div className="flex flex-wrap justify-center gap-5 max-w-fit mx-auto">
-        <span className="flex gap-3">
-          <GlobeIcon />
-          <span>English</span>
-        </span>
-        <span>Press</span>
-        <span>Media</span>
-        <span>Privacy</span>
-        <span>Cookies</span>
-        <span>Contact</span>
-        <span>Help</span>
+        <div className="flex flex-wrap justify-center gap-5 max-w-fit mx-auto">
+          <span className="flex gap-3">
+            <GlobeIcon />
+            <span>English</span>
+          </span>
+          <span>Press</span>
+          <span>Media</span>
+          <span>Privacy</span>
+          <span>Cookies</span>
+          <span>Contact</span>
+          <span>Help</span>
+        </div>
       </div>
     </footer>
   );

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -11,10 +11,10 @@ const Navbar = () => {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <div className="bg-background">
+    <div className="lg:container">
       <nav
         className={cn(
-          "relative pl-0 px-6 py-6 flex justify-between items-center",
+          "relative pl-0 px-6 py-6 flex justify-between items-center"
         )}
       >
         <Link href="/">

--- a/src/components/QuickFilters/QuickFilters.tsx
+++ b/src/components/QuickFilters/QuickFilters.tsx
@@ -1,0 +1,28 @@
+import { Input } from "@/components/ui/input";
+import { Circle, FilterIcon, Map, MessageCircleHeart } from "lucide-react";
+import React from "react";
+import LocationSelect from "../filters/LocationSelect";
+import GenderSelect from "../filters/GenderSelect";
+import { Button } from "../ui/button";
+
+const QuickFilters = () => {
+  return (
+    <div className="flex gap-4 border-y border-border-light p-one">
+      <div className="text-base flex flex-1 overflow-hidden gap-three items-center lg:container">
+        <div className="flex flex-1 items-center gap-one overflow-x-scroll hide-scrollbar lg:gap-two">
+          <Button className="min-w-[35px]" size="icon" variant="primary">
+            <FilterIcon height={35} width={35}/>
+          </Button>
+          <LocationSelect size="sm" />
+          <Input icon={Map} placeholder="Distance" size="sm" />
+          <Input icon={MessageCircleHeart} placeholder="Type" size="sm" />
+          <GenderSelect icon={Circle} size="sm" />
+          <Input placeholder="Age starting from" size="sm" type="number" />
+          <Input placeholder="Age ending at" size="sm" type="number" />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default QuickFilters;

--- a/src/components/QuickFilters/QuickFilters.tsx
+++ b/src/components/QuickFilters/QuickFilters.tsx
@@ -1,5 +1,11 @@
 import { Input } from "@/components/ui/input";
-import { Circle, FilterIcon, Map, MessageCircleHeart } from "lucide-react";
+import {
+  Circle,
+  FilterIcon,
+  Map,
+  MessageCircleHeart,
+  UserRoundPlus,
+} from "lucide-react";
 import React from "react";
 import LocationSelect from "../filters/LocationSelect";
 import GenderSelect from "../filters/GenderSelect";
@@ -11,14 +17,24 @@ const QuickFilters = () => {
       <div className="text-base flex flex-1 overflow-hidden gap-three items-center lg:container">
         <div className="flex flex-1 items-center gap-one overflow-x-scroll hide-scrollbar lg:gap-two">
           <Button className="min-w-[35px]" size="icon" variant="primary">
-            <FilterIcon height={35} width={35}/>
+            <FilterIcon height={35} width={35} />
           </Button>
           <LocationSelect size="sm" />
           <Input icon={Map} placeholder="Distance" size="sm" />
           <Input icon={MessageCircleHeart} placeholder="Type" size="sm" />
           <GenderSelect icon={Circle} size="sm" />
-          <Input placeholder="Age starting from" size="sm" type="number" />
-          <Input placeholder="Age ending at" size="sm" type="number" />
+          <Input
+            icon={UserRoundPlus}
+            placeholder="Age starting from"
+            size="sm"
+            type="number"
+          />
+          <Input
+            icon={UserRoundPlus}
+            placeholder="Age ending at"
+            size="sm"
+            type="number"
+          />
         </div>
       </div>
     </div>

--- a/src/components/QuickFilters/index.ts
+++ b/src/components/QuickFilters/index.ts
@@ -1,0 +1,2 @@
+import QuickFilters from "./QuickFilters";
+export default QuickFilters;

--- a/src/components/filters/GenderSelect/GenderSelect.tsx
+++ b/src/components/filters/GenderSelect/GenderSelect.tsx
@@ -31,7 +31,7 @@ const GenderSelect = ({
         {...other}
         defaultValue={defaultValue}
         hideChevronIcon
-        icon={<BookHeartIcon height={15} width={15} />}
+        icon={BookHeartIcon}
         options={localOptions}
         placeholder="Gender"
         value={value}

--- a/src/components/filters/LocationSelect/LocationSelect.tsx
+++ b/src/components/filters/LocationSelect/LocationSelect.tsx
@@ -43,7 +43,7 @@ const LocationSelect = ({
         {...other}
         defaultValue={defaultValue}
         hideChevronIcon
-        icon={<Map height={15} width={15} />}
+        icon={Map}
         options={localOptions}
         placeholder="Place"
         value={value}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -10,13 +10,13 @@ interface InputProps extends Omit<React.ComponentProps<"input">, "size"> {
 
 const getInputSizeClassname = (size: Size | undefined, hasIcon: boolean) => {
   const inputSizeMap: Record<Size, string> = {
-    sm: cn("h-7 file:text-sm md:text-sm", {
+    sm: cn("h-7 min-w-[100px] file:text-sm md:text-sm", {
       "pl-8": hasIcon,
     }),
-    md: cn("h-9 file:text-md md:text-md", {
+    md: cn("h-9 min-w-[150px] file:text-md md:text-md", {
       "pl-10": hasIcon,
     }),
-    lg: cn("h-11 file:text-lg md:text-lg", {
+    lg: cn("h-11 min-w-[200px] file:text-lg md:text-lg", {
       "pl-12": hasIcon,
     }),
   };

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import { cn } from "@/lib/utils";
+import { getInputIconSizes } from "@/utils/input";
 
 type Size = "sm" | "md" | "lg";
 
@@ -24,26 +25,14 @@ const getInputSizeClassname = (size: Size | undefined, hasIcon: boolean) => {
   return size ? inputSizeMap[size] : inputSizeMap["md"];
 };
 
-const getIconSizeClassname = (size: Size | undefined) => {
-  const iconSizeMap: Record<Size, string> = {
-    sm: "size-4",
-    md: "size-6",
-    lg: "size-8",
-  };
-
-  return size ? iconSizeMap[size] : iconSizeMap["md"];
-};
-
 interface CustomInputProps extends InputProps {
-  icon?: React.ComponentType<{
-    className?: string;
-  }>;
+  icon?: React.ComponentType<React.SVGAttributes<SVGElement>>;
 }
 
 const Input = React.forwardRef<HTMLInputElement, CustomInputProps>(
   ({ icon: IconComponent, className, type, size, ...props }, ref) => {
     const inputSizeClass = getInputSizeClassname(size, !!IconComponent);
-    const iconSizeClass = getIconSizeClassname(size);
+    const [iconWidth, iconHeight] = getInputIconSizes(size);
 
     return (
       <div className="relative h-full w-full max-w-sm items-center">
@@ -59,7 +48,7 @@ const Input = React.forwardRef<HTMLInputElement, CustomInputProps>(
         />
         {IconComponent ? (
           <span className="absolute start-0 inset-y-0 flex items-center justify-center px-2">
-            <IconComponent className={cn(iconSizeClass)} />
+            <IconComponent height={iconHeight} width={iconWidth} />
           </span>
         ) : null}
       </div>

--- a/src/components/ui/select/Select.tsx
+++ b/src/components/ui/select/Select.tsx
@@ -10,6 +10,8 @@ import {
 } from "./components";
 import { SelectProps } from "@radix-ui/react-select";
 import { cn } from "@/lib/utils";
+import { InputSize } from "@/types/input";
+import { getInputIconSizes } from "@/utils/input";
 
 export interface Option {
   value: string;
@@ -21,17 +23,15 @@ export interface GroupedOption {
   items: Option[];
 }
 
-export type SelectSize = "sm" | "md" | "lg";
-
 export interface SelectComponentProps extends SelectProps {
   options: Option[] | GroupedOption[];
   placeholder?: string;
-  icon?: React.ReactNode;
+  icon?: React.ComponentType<React.SVGAttributes<SVGElement>>;
   hideChevronIcon?: boolean;
-  size?: SelectSize;
+  size?: InputSize;
 }
 
-const sizeClasses: Record<SelectSize, string> = {
+const sizeClasses: Record<InputSize, string> = {
   sm: "h-7 text-sm min-w-[100px]",
   md: "h-9 text-sm min-w-[150px]",
   lg: "h-11 text-sm min-w-[200px]",
@@ -40,12 +40,13 @@ const sizeClasses: Record<SelectSize, string> = {
 const Select: React.FC<SelectComponentProps> = ({
   options,
   placeholder = "Select...",
-  icon,
+  icon: IconComponent,
   hideChevronIcon = false,
   size = "md",
   ...other
 }) => {
   const isGrouped = "items" in options[0];
+  const [iconWidth, iconHeight] = getInputIconSizes(size);
 
   return (
     <SelectComponent {...other}>
@@ -58,9 +59,11 @@ const Select: React.FC<SelectComponentProps> = ({
           sizeClasses[size]
         )}
       >
-        {icon ? (
+        {IconComponent ? (
           <div className="flex items-center">
-            <span className="mr-2 max-h-fit">{icon}</span>
+            <span className="mr-2 max-h-fit">
+              <IconComponent height={iconWidth} width={iconHeight} />
+            </span>
             <SelectValue placeholder={placeholder} />
           </div>
         ) : (

--- a/src/components/ui/select/index.ts
+++ b/src/components/ui/select/index.ts
@@ -1,9 +1,4 @@
 import Select from "./Select";
 
-export type {
-  GroupedOption,
-  Option,
-  SelectSize,
-  SelectComponentProps,
-} from "./Select";
+export type { GroupedOption, Option, SelectComponentProps } from "./Select";
 export default Select;

--- a/src/types/input.ts
+++ b/src/types/input.ts
@@ -1,0 +1,1 @@
+export type InputSize = "sm" | "md" | "lg";

--- a/src/utils/input.ts
+++ b/src/utils/input.ts
@@ -1,0 +1,11 @@
+import { InputSize } from "@/types/input";
+
+export const getInputIconSizes = (size: InputSize = "md"): [number, number] => {
+  const iconSizeMap: Record<InputSize, [number, number]> = {
+    sm: [16, 16],
+    md: [22, 22],
+    lg: [28, 28],
+  };
+
+  return iconSizeMap[size];
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -57,7 +57,10 @@ const config: Config = {
           DEFAULT: "var(--eros-white)",
           foreground: "var(--eros-pink)",
         },
-        border: "var(--border)",
+        border: {
+          DEFAULT: "var(--border)",
+          light: "rgba(255, 255, 255, 0.05)",
+        },
       },
       fontSize: {
         "4xl": ["2.986rem", "3.75rem"],


### PR DESCRIPTION
### Link to issue

[EEMW-11]

### Description

- Quick filter component (only visually for now)
- Support for passing icons as react component type to Select and Input components
- Default icon width & height based on size prop.

### Desktop

![Screenshot 2024-11-14 at 21 49 36](https://github.com/user-attachments/assets/714d9d0c-3252-49de-98a9-ee4c3862fefb)

### Mobile

https://github.com/user-attachments/assets/13b3ce47-49e6-4774-a559-709bf6526356


[EEMW-11]: https://wdc-digital.atlassian.net/browse/EEMW-11?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ