### PR TITLE
[EEMW] | Add new import sort-order rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,6 +11,28 @@
   "ignorePatterns": ["dist", ".eslintrc.cjs"],
   "parser": "@typescript-eslint/parser",
   "rules": {
+    "import/order": [
+      "error",
+      {
+        "newlines-between": "always",
+        "alphabetize": { "order": "asc" },
+        "groups": [
+          "builtin", // Node.js built-in moduls
+          "external", // External libraries
+          "internal", // Aliases
+          ["parent", "sibling"], // Relative imports
+          "index" // Index imports './'
+        ],
+        "pathGroups": [
+          {
+            "pattern": "@/**",
+            "group": "internal",
+            "position": "before" // before relative imports
+          }
+        ],
+        "pathGroupsExcludedImportTypes": ["builtin"]
+      }
+    ],
     "react/prefer-stateless-function": "error",
     "react/button-has-type": "error",
     "react/no-unused-prop-types": "error",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,11 +2,11 @@ import type { Metadata } from "next";
 import localFont from "next/font/local";
 
 import Footer from "@/components/Footer";
+import Navbar from "@/components/Navbar";
+import QuickFilters from "@/components/QuickFilters";
+import Breadcrumbs from "@/components/breadcrumbs";
 
 import "./globals.css";
-import QuickFilters from "@/components/QuickFilters";
-import Navbar from "@/components/Navbar";
-import Breadcrumbs from "@/components/breadcrumbs";
 
 const ceraPro = localFont({
   src: [

--- a/src/app/playground/page.tsx
+++ b/src/app/playground/page.tsx
@@ -1,11 +1,11 @@
+import { PiIcon, MapIcon, Map } from "lucide-react";
+
+import Accordion from "@/components/ui/accordion";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import Select from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { TooltipWrap } from "@/components/ui/tooltip";
-import Select from "@/components/ui/select";
-import Accordion from "@/components/ui/accordion";
-
-import { PiIcon, MapIcon, Map } from "lucide-react";
 
 const TooltipedButton = TooltipWrap(Button);
 

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useState } from "react";
-import Link from "next/link";
 import { GlobeIcon, MenuIcon, XIcon } from "lucide-react";
 import Image from "next/image";
+import Link from "next/link";
+import { useState } from "react";
+
 import { cn } from "@/lib/utils";
+
 import { navigationLinks } from "./constants";
 
 const Navbar = () => {

--- a/src/components/QuickFilters/QuickFilters.tsx
+++ b/src/components/QuickFilters/QuickFilters.tsx
@@ -1,4 +1,3 @@
-import { Input } from "@/components/ui/input";
 import {
   Circle,
   FilterIcon,
@@ -7,8 +6,11 @@ import {
   UserRoundPlus,
 } from "lucide-react";
 import React from "react";
-import LocationSelect from "../filters/LocationSelect";
+
+import { Input } from "@/components/ui/input";
+
 import GenderSelect from "../filters/GenderSelect";
+import LocationSelect from "../filters/LocationSelect";
 import { Button } from "../ui/button";
 
 const QuickFilters = () => {

--- a/src/components/breadcrumbs/BreadCrumbs.tsx
+++ b/src/components/breadcrumbs/BreadCrumbs.tsx
@@ -1,12 +1,13 @@
 "use client";
 
+import { ChevronsRightIcon, LucideHouse } from "lucide-react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
 import React from "react";
 
-import { usePathname } from "next/navigation";
-import Link from "next/link";
-import { ChevronsRightIcon, LucideHouse } from "lucide-react";
-import { navigationLinks } from "../Navbar/constants";
 import { cn } from "@/lib/utils";
+
+import { navigationLinks } from "../Navbar/constants";
 
 const SeparatorElement = ({ fill = false }: { fill: boolean }) => (
   <ChevronsRightIcon

--- a/src/components/ui/accordion/Accordion.tsx
+++ b/src/components/ui/accordion/Accordion.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+
 import {
   AccordionComponent,
   AccordionItem,

--- a/src/components/ui/accordion/components.tsx
+++ b/src/components/ui/accordion/components.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import * as React from "react";
 import * as AccordionPrimitive from "@radix-ui/react-accordion";
 import { ChevronDown } from "lucide-react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -54,4 +54,9 @@ const AccordionContent = React.forwardRef<
 ));
 AccordionContent.displayName = AccordionPrimitive.Content.displayName;
 
-export { AccordionComponent, AccordionItem, AccordionTrigger, AccordionContent };
+export {
+  AccordionComponent,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
+};

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -9,10 +9,8 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        primary:
-          "bg-primary text-primary-foreground hover:opacity-85",
-        success:
-          "bg-success text-success-foreground hover:opacity-85",
+        primary: "bg-primary text-primary-foreground hover:opacity-85",
+        success: "bg-success text-success-foreground hover:opacity-85",
         destructive:
           "bg-destructive text-destructive-foreground hover:opacity-85",
         outline:

--- a/src/components/ui/select/Select.tsx
+++ b/src/components/ui/select/Select.tsx
@@ -1,4 +1,10 @@
+import { SelectProps } from "@radix-ui/react-select";
 import * as React from "react";
+
+import { cn } from "@/lib/utils";
+import { InputSize } from "@/types/input";
+import { getInputIconSizes } from "@/utils/input";
+
 import {
   SelectComponent,
   SelectTrigger,
@@ -8,10 +14,6 @@ import {
   SelectGroup,
   SelectValue,
 } from "./components";
-import { SelectProps } from "@radix-ui/react-select";
-import { cn } from "@/lib/utils";
-import { InputSize } from "@/types/input";
-import { getInputIconSizes } from "@/utils/input";
 
 export interface Option {
   value: string;

--- a/src/components/ui/select/components.tsx
+++ b/src/components/ui/select/components.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import * as React from "react";
 import * as SelectPrimitive from "@radix-ui/react-select";
 import { Check, ChevronDown, ChevronUp } from "lucide-react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,5 +1,6 @@
-import * as React from "react";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import * as React from "react";
+
 import { cn } from "@/lib/utils";
 
 interface TooltipContentProps extends TooltipPrimitive.TooltipContentProps {
@@ -41,7 +42,11 @@ function TooltipWrap<E extends React.ElementType>(
             sideOffset={4}
           >
             {tooltip}
-            <TooltipPrimitive.Arrow className="TooltipArrow" color="var(--tooltip)" fill="var(--tooltip)" />
+            <TooltipPrimitive.Arrow
+              className="TooltipArrow"
+              color="var(--tooltip)"
+              fill="var(--tooltip)"
+            />
           </TooltipPrimitive.Content>
         </TooltipPrimitive.Tooltip>
       </TooltipPrimitive.TooltipProvider>


### PR DESCRIPTION
### Description

Adds rule to sort the imports from the external libraries to relative paths top to bottom, in an ascending order.
