### PR TITLE
[EEMW] | Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 3
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,7 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 3
-
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @eniskrasniqi-mest


### PR DESCRIPTION
### Description

Adds dependabot for npm packages and our github-actions.


### To Do

This will need configuring the repositories as well to allow dependabot:
https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide#enabling-dependabot-for-your-repository


